### PR TITLE
#59

### DIFF
--- a/deployer/src/main/java/zed/deployer/executor/DefaultProcessExecutor.java
+++ b/deployer/src/main/java/zed/deployer/executor/DefaultProcessExecutor.java
@@ -1,5 +1,6 @@
 package zed.deployer.executor;
 
+import zed.deployer.StatusResolver;
 import zed.deployer.manager.DeployableDescriptor;
 import zed.deployer.manager.DeployablesManager;
 
@@ -11,9 +12,13 @@ public class DefaultProcessExecutor implements ProcessExecutor {
 
     private final List<ProcessExecutorHandler> handlers;
 
-    public DefaultProcessExecutor(DeployablesManager deployableManager, List<ProcessExecutorHandler> handlers) {
+    private final StatusResolver statusResolver;
+
+    public DefaultProcessExecutor(DeployablesManager deployableManager, List<ProcessExecutorHandler> handlers,
+                                  StatusResolver statusResolver) {
         this.handlers = handlers;
         this.deployableManager = deployableManager;
+        this.statusResolver = statusResolver;
     }
 
     @Override
@@ -21,6 +26,9 @@ public class DefaultProcessExecutor implements ProcessExecutor {
         DeployableDescriptor descriptor = deployableManager.deployment(deploymentId);
         for (ProcessExecutorHandler handler : handlers) {
             if (handler.supports(descriptor.uri())) {
+                if (statusResolver.status(deploymentId)) {
+                    return descriptor.pid();
+                }
                 String pid = handler.start(deploymentId);
                 deployableManager.update(descriptor.pid(pid));
                 return pid;

--- a/deployer/src/main/java/zed/deployer/executor/DefaultProcessExecutor.java
+++ b/deployer/src/main/java/zed/deployer/executor/DefaultProcessExecutor.java
@@ -5,6 +5,7 @@ import zed.deployer.manager.DeployableDescriptor;
 import zed.deployer.manager.DeployablesManager;
 
 import java.util.List;
+import java.util.Optional;
 
 public class DefaultProcessExecutor implements ProcessExecutor {
 
@@ -22,16 +23,16 @@ public class DefaultProcessExecutor implements ProcessExecutor {
     }
 
     @Override
-    public String start(String deploymentId) {
+    public Optional<String> start(String deploymentId) {
         DeployableDescriptor descriptor = deployableManager.deployment(deploymentId);
         for (ProcessExecutorHandler handler : handlers) {
             if (handler.supports(descriptor.uri())) {
                 if (statusResolver.status(deploymentId)) {
-                    return descriptor.pid();
+                    return Optional.empty();
                 }
                 String pid = handler.start(deploymentId);
                 deployableManager.update(descriptor.pid(pid));
-                return pid;
+                return Optional.of(pid);
             }
         }
         throw new RuntimeException("No executor handler for URI: " + descriptor.uri());

--- a/deployer/src/main/java/zed/deployer/executor/ProcessExecutor.java
+++ b/deployer/src/main/java/zed/deployer/executor/ProcessExecutor.java
@@ -1,7 +1,9 @@
 package zed.deployer.executor;
 
+import java.util.Optional;
+
 public interface ProcessExecutor {
 
-    String start(String deploymentId);
+    Optional<String> start(String deploymentId);
 
 }

--- a/deployer/src/main/java/zed/deployer/spring/DeployerAutoConfiguration.java
+++ b/deployer/src/main/java/zed/deployer/spring/DeployerAutoConfiguration.java
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import zed.deployer.StatusResolver;
 import zed.deployer.executor.*;
 import zed.deployer.manager.DeployablesManager;
 import zed.deployer.manager.LocalFileSystemZedHome;
@@ -27,8 +28,9 @@ public class DeployerAutoConfiguration {
     // Process executor
 
     @Bean
-    ProcessExecutor defaultProcessExecutor(DeployablesManager deployablesManager, ProcessExecutorHandler[] handlers) {
-        return new DefaultProcessExecutor(deployablesManager, asList(handlers));
+    ProcessExecutor defaultProcessExecutor(DeployablesManager deployablesManager, ProcessExecutorHandler[] handlers,
+                                           StatusResolver statusResolver) {
+        return new DefaultProcessExecutor(deployablesManager, asList(handlers), statusResolver);
     }
 
     @Bean

--- a/deployer/src/test/java/zed/deployer/executor/DefaultProcessExecutorTest.java
+++ b/deployer/src/test/java/zed/deployer/executor/DefaultProcessExecutorTest.java
@@ -1,6 +1,7 @@
 package zed.deployer.executor;
 
 import com.github.dockerjava.api.DockerClient;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -20,6 +21,7 @@ import zed.deployer.manager.ZedHome;
 import zed.dockerunit.BaseDockerTest;
 
 import java.io.File;
+import java.util.Optional;
 
 import static com.google.common.io.Files.createTempDir;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
@@ -41,7 +43,7 @@ public class DefaultProcessExecutorTest extends BaseDockerTest {
     @Autowired
     ProcessExecutor defaultProcessExecutor;
 
-    String pid;
+    Optional<String> pid;
 
     @BeforeClass
     public static void beforeClass() {
@@ -63,11 +65,11 @@ public class DefaultProcessExecutorTest extends BaseDockerTest {
             pid = defaultProcessExecutor.start(descriptor.id());
 
             // Then
-            assertNotNull(pid);
+            assertNotNull(pid.get());
         } finally {
             if (pid != null) {
-                docker().stopContainerCmd(pid).exec();
-                docker().removeContainerCmd(pid).withForce().exec();
+                docker().stopContainerCmd(pid.get()).exec();
+                docker().removeContainerCmd(pid.get()).withForce().exec();
             }
         }
     }
@@ -80,17 +82,17 @@ public class DefaultProcessExecutorTest extends BaseDockerTest {
 
             // When
             pid = defaultProcessExecutor.start(descriptor.id());
-            dockerTester.registerShutdown(pid);
+            dockerTester.registerShutdown(pid.get());
 
             // Then
-            assertTrue(isNotEmpty(pid));
-            assertTrue(docker().inspectContainerCmd(pid).exec().getState().isRunning());
-            assertTrue(docker().inspectContainerCmd(pid).exec().getConfig().getImage().contains("dockerfile/mongodb"));
-            assertThat(volumeBinds(docker(), pid), hasVolume("/data/db", "/var/zed/mongodb/default"));
+            assertTrue(isNotEmpty(pid.get()));
+            assertTrue(docker().inspectContainerCmd(pid.get()).exec().getState().isRunning());
+            assertTrue(docker().inspectContainerCmd(pid.get()).exec().getConfig().getImage().contains("dockerfile/mongodb"));
+            assertThat(volumeBinds(docker(), pid.get()), hasVolume("/data/db", "/var/zed/mongodb/default"));
         } finally {
-            if (pid != null) {
-                docker().stopContainerCmd(pid).exec();
-                docker().removeContainerCmd(pid).withForce().exec();
+            if (pid.isPresent() && StringUtils.isNotEmpty(pid.get())) {
+                docker().stopContainerCmd(pid.get()).exec();
+                docker().removeContainerCmd(pid.get()).withForce().exec();
             }
         }
     }
@@ -103,16 +105,16 @@ public class DefaultProcessExecutorTest extends BaseDockerTest {
             pid = defaultProcessExecutor.start(descriptor.id());
 
             // Then
-            String pid2 = defaultProcessExecutor.start(descriptor.id());
+            Optional<String> pid2 = defaultProcessExecutor.start(descriptor.id());
 
             // Then
-            assertNotNull(pid);
-            assertEquals(pid, pid2);
+            assertNotNull(pid.get());
+            assertFalse(pid2.isPresent());
             assertEquals(deployableManager.list().size(), 1);
         } finally {
             if (pid != null) {
-                docker().stopContainerCmd(pid).exec();
-                docker().removeContainerCmd(pid).withForce().exec();
+                docker().stopContainerCmd(pid.get()).exec();
+                docker().removeContainerCmd(pid.get()).withForce().exec();
             }
         }
     }

--- a/deployer/src/test/java/zed/deployer/executor/DefaultProcessExecutorTest.java
+++ b/deployer/src/test/java/zed/deployer/executor/DefaultProcessExecutorTest.java
@@ -95,6 +95,28 @@ public class DefaultProcessExecutorTest extends BaseDockerTest {
         }
     }
 
+    @Test
+    public void shouldStartDeployableOnce() {
+        try {
+            // Given
+            DeployableDescriptor descriptor = deployableManager.deploy("docker:" + TEST_IMAGE);
+            pid = defaultProcessExecutor.start(descriptor.id());
+
+            // Then
+            String pid2 = defaultProcessExecutor.start(descriptor.id());
+
+            // Then
+            assertNotNull(pid);
+            assertEquals(pid, pid2);
+            assertEquals(deployableManager.list().size(), 1);
+        } finally {
+            if (pid != null) {
+                docker().stopContainerCmd(pid).exec();
+                docker().removeContainerCmd(pid).withForce().exec();
+            }
+        }
+    }
+
 }
 
 @SpringBootApplication

--- a/shell/src/main/resources/commands/deploy_start.groovy
+++ b/shell/src/main/resources/commands/deploy_start.groovy
@@ -14,12 +14,12 @@ class deploy_start {
     def main(InvocationContext context, @Required @Argument String deploymentId) {
         ProcessExecutor processExecutor = context.getAttributes().get('spring.beanfactory').getBean(ProcessExecutor.class)
         DeployablesManager deployer = context.getAttributes().get('spring.beanfactory').getBean(DeployablesManager.class)
-        StatusResolver statusResolver = context.getAttributes().get('spring.beanfactory').getBean(StatusResolver.class)
-        if (statusResolver.status(deploymentId)) {
+        def pid = processExecutor.start(deploymentId)
+        if (pid.isPresent()) {
+            return "Deployment ${deploymentId} has been started with PID ${pid.get()}."
+        } else {
             return "Deployment ${deploymentId} is already running on PID ${deployer?.deployment(deploymentId)?.pid()}."
         }
-        def pid = processExecutor.start(deploymentId)
-        return "Deployment ${deploymentId} has been started with PID ${pid}."
     }
 
 }

--- a/shell/src/main/resources/commands/deploy_start.groovy
+++ b/shell/src/main/resources/commands/deploy_start.groovy
@@ -4,13 +4,20 @@ import org.crsh.cli.Argument
 import org.crsh.cli.Command
 import org.crsh.cli.Required
 import org.crsh.command.InvocationContext
+import zed.deployer.StatusResolver
 import zed.deployer.executor.ProcessExecutor
+import zed.deployer.manager.DeployablesManager
 
 class deploy_start {
 
     @Command
     def main(InvocationContext context, @Required @Argument String deploymentId) {
         ProcessExecutor processExecutor = context.getAttributes().get('spring.beanfactory').getBean(ProcessExecutor.class)
+        DeployablesManager deployer = context.getAttributes().get('spring.beanfactory').getBean(DeployablesManager.class)
+        StatusResolver statusResolver = context.getAttributes().get('spring.beanfactory').getBean(StatusResolver.class)
+        if (statusResolver.status(deploymentId)) {
+            return "Deployment ${deploymentId} is already running on PID ${deployer?.deployment(deploymentId)?.pid()}."
+        }
         def pid = processExecutor.start(deploymentId)
         return "Deployment ${deploymentId} has been started with PID ${pid}."
     }

--- a/shell/src/main/resources/commands/deploy_start_all.groovy
+++ b/shell/src/main/resources/commands/deploy_start_all.groovy
@@ -13,15 +13,14 @@ class deploy_start_all {
     def main(InvocationContext context) {
         ProcessExecutor processExecutor = context.getAttributes().get('spring.beanfactory').getBean(ProcessExecutor.class)
         DeployablesManager deployer = context.getAttributes().get('spring.beanfactory').getBean(DeployablesManager.class)
-        StatusResolver statusResolver = context.getAttributes().get('spring.beanfactory').getBean(StatusResolver.class)
         String message = ""
         for (DeployableDescriptor descriptor : deployer.list()) {
-            if (statusResolver.status(descriptor.id())) {
-                message += "Deployment ${descriptor.id()} is already running on PID ${descriptor.pid()}.\n"
-                continue
-            }
             def pid = processExecutor.start(descriptor.id())
-            message += "Deployment ${descriptor.id()} has been started with PID ${pid}.\n"
+            if (pid.isPresent()) {
+                message += "Deployment ${descriptor.id()} has been started with PID ${pid.get()}.\n"
+            } else {
+                message += "Deployment ${descriptor.id()} is already running on PID ${descriptor.pid()}.\n"
+            }
         }
         return message
     }

--- a/shell/src/main/resources/commands/deploy_start_all.groovy
+++ b/shell/src/main/resources/commands/deploy_start_all.groovy
@@ -2,6 +2,7 @@ package commands
 
 import org.crsh.cli.Command
 import org.crsh.command.InvocationContext
+import zed.deployer.StatusResolver
 import zed.deployer.executor.ProcessExecutor
 import zed.deployer.manager.DeployableDescriptor
 import zed.deployer.manager.DeployablesManager
@@ -12,8 +13,13 @@ class deploy_start_all {
     def main(InvocationContext context) {
         ProcessExecutor processExecutor = context.getAttributes().get('spring.beanfactory').getBean(ProcessExecutor.class)
         DeployablesManager deployer = context.getAttributes().get('spring.beanfactory').getBean(DeployablesManager.class)
+        StatusResolver statusResolver = context.getAttributes().get('spring.beanfactory').getBean(StatusResolver.class)
         String message = ""
         for (DeployableDescriptor descriptor : deployer.list()) {
+            if (statusResolver.status(descriptor.id())) {
+                message += "Deployment ${descriptor.id()} is already running on PID ${descriptor.pid()}.\n"
+                continue
+            }
             def pid = processExecutor.start(descriptor.id())
             message += "Deployment ${descriptor.id()} has been started with PID ${pid}.\n"
         }


### PR DESCRIPTION
I added extra check before starting deployable which should be fine, but I also had to adjust messages from shell scripts as there should be a different message when process was not started because it was already running - for this I had to check status second time, which is not a perfect solution. 

Is there any other way to handle different message in shell script? The only idea I have is to extend <code>DeployableDescriptor</code> so that it could return deployable status.