### PR TITLE
Issue 66

### DIFF
--- a/deployer/src/main/java/zed/deployer/executor/BaseDockerProcessExecutorHandler.java
+++ b/deployer/src/main/java/zed/deployer/executor/BaseDockerProcessExecutorHandler.java
@@ -37,20 +37,7 @@ public class BaseDockerProcessExecutorHandler implements ProcessExecutorHandler 
         try {
             DeployableDescriptor descriptor = deployableManager.deployment(deploymentId);
 
-            String pid;
-            if (name(descriptor) != null) {
-                List<Container> containers = docker.listContainersCmd().withShowAll(true).exec();
-                containers = containers.parallelStream().filter(c -> asList(c.getNames()).contains("/" + name(descriptor))).collect(Collectors.toList());
-                if (containers.size() == 0) {
-                    pid = docker.createContainerCmd(getImageName(descriptor)).withName(name(descriptor)).withEnv(envVariables(descriptor)).exec().getId();
-                } else {
-                    pid = containers.get(0).getId();
-                }
-            } else {
-                pid = docker.createContainerCmd(getImageName(descriptor)).withEnv(envVariables(descriptor)).exec().getId();
-            }
-
-            StartContainerCmd startContainer = docker.startContainerCmd(pid);
+            StartContainerCmd startContainer = docker.startContainerCmd(descriptor.pid());
             if (portToExpose(descriptor) != null) {
                 startContainer.withPortBindings(PortBinding.parse(portToExpose(descriptor) + ":" + portToExpose(descriptor)));
             }
@@ -59,20 +46,11 @@ public class BaseDockerProcessExecutorHandler implements ProcessExecutorHandler 
             }
             startContainer.exec();
 
-            deployableManager.update(descriptor.pid(pid));
-            return pid;
+            return descriptor.pid();
         } catch (Exception e) {
             throw new RuntimeException(e);
 
         }
-    }
-
-    protected String getImageName(DeployableDescriptor descriptor) {
-        return DockerUriUtil.imageName(URI_PREFIX, descriptor.uri());
-    }
-
-    protected String name(DeployableDescriptor deployableDescriptor) {
-        return null;
     }
 
     protected Integer portToExpose(DeployableDescriptor deployableDescriptor) {
@@ -81,10 +59,6 @@ public class BaseDockerProcessExecutorHandler implements ProcessExecutorHandler 
 
     protected String volume(DeployableDescriptor deployableDescriptor) {
         return null;
-    }
-
-    protected String[] envVariables(DeployableDescriptor deployableDescriptor) {
-        return DockerUriUtil.environmentVariables(deployableDescriptor.uri());
     }
 
 }

--- a/deployer/src/main/java/zed/deployer/executor/MongoDbDockerProcessExecutorHandler.java
+++ b/deployer/src/main/java/zed/deployer/executor/MongoDbDockerProcessExecutorHandler.java
@@ -8,8 +8,6 @@ public class MongoDbDockerProcessExecutorHandler extends BaseDockerProcessExecut
 
     private static final String URI_PREFIX = "mongodb:docker";
 
-    private static final String MONGO_IMAGE = "dockerfile/mongodb";
-
     public MongoDbDockerProcessExecutorHandler(DeployablesManager deployableManager, DockerClient docker) {
         super(deployableManager, docker);
     }
@@ -20,16 +18,6 @@ public class MongoDbDockerProcessExecutorHandler extends BaseDockerProcessExecut
     }
 
     // Container configuration
-
-    @Override
-    protected String getImageName(DeployableDescriptor descriptor) {
-        return MONGO_IMAGE;
-    }
-
-    @Override
-    protected String name(DeployableDescriptor deployableDescriptor) {
-        return "mongodb";
-    }
 
     @Override
     protected Integer portToExpose(DeployableDescriptor deployableDescriptor) {

--- a/deployer/src/main/java/zed/deployer/handlers/DeployableHandler.java
+++ b/deployer/src/main/java/zed/deployer/handlers/DeployableHandler.java
@@ -6,6 +6,6 @@ public interface DeployableHandler {
 
     boolean supports(String uri);
 
-    void deploy(DeployableDescriptor deployableDescriptor);
+    DeployableDescriptor deploy(DeployableDescriptor deployableDescriptor);
 
 }

--- a/deployer/src/main/java/zed/deployer/handlers/FatJarMavenDeployableHandler.java
+++ b/deployer/src/main/java/zed/deployer/handlers/FatJarMavenDeployableHandler.java
@@ -33,7 +33,7 @@ public class FatJarMavenDeployableHandler implements DeployableHandler {
     }
 
     @Override
-    public void deploy(DeployableDescriptor deployableDescriptor) {
+    public DeployableDescriptor deploy(DeployableDescriptor deployableDescriptor) {
         try {
             String mavenCoordinatesUri = deployableDescriptor.uri().substring(URI_PREFIX.length());
             String[] mavenCoordinates = mavenCoordinatesUri.split("/");
@@ -44,6 +44,7 @@ public class FatJarMavenDeployableHandler implements DeployableHandler {
             InputStream artifactData = mavenArtifactResolver.artifactStream(mavenCoordinates[0].replaceAll("\\.", "/"), mavenCoordinates[1].replaceAll("\\.", "/"), mavenCoordinates[2], artifactType);
             File deployDirectory = new File(workspace, mavenCoordinates[1] + "-" + mavenCoordinates[2] + "." + artifactType);
             IOUtils.copy(artifactData, new FileOutputStream(deployDirectory));
+            return deployableDescriptor;
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/deployer/src/main/java/zed/deployer/handlers/MongoDbDockerDeployableHandler.java
+++ b/deployer/src/main/java/zed/deployer/handlers/MongoDbDockerDeployableHandler.java
@@ -18,7 +18,17 @@ public class MongoDbDockerDeployableHandler extends BaseDockerDeployableHandler 
     }
 
     @Override
-    public void deploy(DeployableDescriptor deployableDescriptor) {
+    protected void pullDockerImage(DeployableDescriptor deployableDescriptor) {
         asString(docker().pullImageCmd(MONGO_IMAGE).exec());
+    }
+
+    @Override
+    protected String getImageName(DeployableDescriptor descriptor) {
+        return MONGO_IMAGE;
+    }
+
+    @Override
+    protected String name(DeployableDescriptor deployableDescriptor) {
+        return "mongodb";
     }
 }

--- a/deployer/src/main/java/zed/deployer/manager/FileSystemDeployablesManager.java
+++ b/deployer/src/main/java/zed/deployer/manager/FileSystemDeployablesManager.java
@@ -35,9 +35,10 @@ public class FileSystemDeployablesManager implements DeployablesManager {
         BasicDeployableDescriptor deploymentDescriptor = new BasicDeployableDescriptor(workspace.getName(), id, uri);
         for (DeployableHandler deployHandler : deployHandlers) {
             if (deployHandler.supports(uri)) {
-                deployHandler.deploy(deploymentDescriptor);
-                deploymentDescriptor.save(new File(workspace, deploymentDescriptor.id() + ".deploy"));
-                return deploymentDescriptor;
+                DeployableDescriptor deployableDescriptor = deployHandler.deploy(deploymentDescriptor);
+                deploymentDescriptor.save(new File(workspace, deployableDescriptor.id() + ".deploy"));
+                this.update(deployableDescriptor);
+                return deployableDescriptor;
             }
         }
         throw new RuntimeException("No handler for deployable with URI: " + uri);

--- a/deployer/src/test/java/zed/deployer/FileSystemDeployablesManagerTest.java
+++ b/deployer/src/test/java/zed/deployer/FileSystemDeployablesManagerTest.java
@@ -111,9 +111,12 @@ public class FileSystemDeployablesManagerTest extends Assert {
 
     @Test
     public void shouldWriteUriIntoDockerDescriptor() throws IOException {
+
+        // Given
+        assumeTrue(isConnected(docker));
+
         try {
             // When
-            assumeTrue(isConnected(docker));
             deployableDescriptor = deploymentManager.deploy("docker:" + TEST_IMAGE);
 
             // Then
@@ -129,10 +132,11 @@ public class FileSystemDeployablesManagerTest extends Assert {
 
     @Test
     public void shouldWriteIdIntoDockerDescriptor() throws IOException {
-        try {
-            // Given
-            assumeTrue(isConnected(docker));
 
+        // Given
+        assumeTrue(isConnected(docker));
+
+        try {
             // When
             deployableDescriptor = deploymentManager.deploy("docker:" + TEST_IMAGE);
 
@@ -149,10 +153,11 @@ public class FileSystemDeployablesManagerTest extends Assert {
 
     @Test
     public void shouldUpdateDockerPidDuringDeploy() throws IOException {
-        try {
-            // Given
-            assumeTrue(isConnected(docker));
 
+        // Given
+        assumeTrue(isConnected(docker));
+
+        try {
             // When
             deployableDescriptor = deploymentManager.deploy("docker:" + TEST_IMAGE);
 


### PR DESCRIPTION
@hekonsek due to moving creation of docker container to deployment handler I had to change return type of <code>DeployableHandler#deploy</code> method from <code>void</code> to <code>DeployableDescriptor</code> because if it comes to docker handler we need to return new <code>DeployableDescriptor</code> with <code>pid</code>. Is it ok, or you have got other idea to handle this?